### PR TITLE
Added pixi configuration files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+# pixi environments
+.pixi
+*.egg-info

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,30 @@
+[project]
+authors = ["Esteve Fernandez <esteve@apache.org>"]
+channels = ["robostack-staging", "conda-forge"]
+description = "Implement the ROS middleware interface using libp2p"
+name = "rmw_libp2p_cpp"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[activation]
+scripts = ["install/setup.sh"]
+
+[tasks]
+build = "colcon build --symlink-install"
+
+[dependencies]
+rust = ">=1.81.0,<2"
+ros-humble-ament-lint-auto = ">=0.12.10,<0.13"
+ros-humble-rcpputils = ">=2.4.1,<3"
+ros-humble-rcutils = ">=5.1.4,<6"
+ros-humble-rmw = ">=6.1.1,<7"
+ros-humble-rosidl-typesupport-introspection-c = ">=3.1.5,<4"
+ros-humble-rosidl-typesupport-introspection-cpp = ">=3.1.5,<4"
+ros-humble-ament-lint-common = ">=0.12.10,<0.13"
+ros-humble-osrf-testing-tools-cpp = ">=1.5.2,<2"
+ros-humble-test-msgs = ">=1.2.1,<2"
+ros-humble-ament-cmake-ros = ">=0.10.0,<0.11"
+ros-humble-ament-cmake = ">=1.3.7,<2"
+
+[build-dependencies]
+colcon-common-extensions = ">=0.3.0,<0.4"

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,8 @@ scripts = ["install/setup.sh"]
 
 [tasks]
 build = "colcon build --symlink-install"
+publisher = { cmd = "ros2 run examples_rclpy_minimal_publisher publisher_old_school", env={ RMW_IMPLEMENTATION="rmw_libp2p_cpp" }, depends-on="build" }
+subscriber = { cmd = "ros2 run examples_rclpy_minimal_subscriber subscriber_old_school", env={ RMW_IMPLEMENTATION="rmw_libp2p_cpp" }, depends-on="build" }
 
 [dependencies]
 rust = ">=1.81.0,<2"
@@ -25,6 +27,12 @@ ros-humble-osrf-testing-tools-cpp = ">=1.5.2,<2"
 ros-humble-test-msgs = ">=1.2.1,<2"
 ros-humble-ament-cmake-ros = ">=0.10.0,<0.11"
 ros-humble-ament-cmake = ">=1.3.7,<2"
+
+# minimal examples to test the rmw layer
+ros-humble-examples-rclpy-minimal-publisher = ">=0.15.1,<0.16"
+ros-humble-examples-rclpy-minimal-subscriber = ">=0.15.1,<0.16"
+ros-humble-ros2cli = ">=0.18.8,<0.19"
+ros-humble-ros2run = ">=0.18.8,<0.19"
 
 [build-dependencies]
 colcon-common-extensions = ">=0.3.0,<0.4"


### PR DESCRIPTION
This PR adds support for building `rmw_libp2p` via [Pixi](https://pixi.sh/latest/)