### PR TITLE
ci: update CI to use the Rust 1.85 toolchain. Fix GPG key for OSRF repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Open Robotics GPG key
+      run: |
+        rm -fv /etc/apt/sources.list.d/ros2.list
+        apt-get update && apt-get install curl -y
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
+        dpkg -i /tmp/ros2-apt-source.deb
+
     - name: Search packages in this repository
       id: list_packages
       run: |
@@ -45,12 +53,12 @@ jobs:
         required-ros-distributions: ${{ matrix.ros_distro }}
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@1.78
+      uses: dtolnay/rust-toolchain@1.85
       with:
         components: clippy, rustfmt
 
     - name: build and test
-      uses: ros-tooling/action-ros-ci@v0.3
+      uses: ros-tooling/action-ros-ci@v0.4
       with:
         package-name: ${{ steps.list_packages.outputs.package_list }}
         target-ros2-distro: ${{ matrix.ros_distro }}


### PR DESCRIPTION
This PR updates the CI workflow with the Rust 1.85 toolchain and use the `ros2-apt-source.deb` package to set up the APT GnuPG key.